### PR TITLE
Fixed the AudioContext object dropping bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There is an interesting fact which is causing me to pause and add something on t
 ## Housekeeping Notes
 For me or anyone who wants to help with bugfixes/optimization
 
-- AudioContext object sometimes drops, including in dev on any page changes (probably unavoidable) but also randomly if too many clicks
+- Activating a note repeatedly and quickly causes a sharp noise to occur
 - Adding keybindings to stuff to play the keyboard more like a piano
 - Moving that godawful styling case/elseif nightmare to some more readable separate helper function(s)
 - Chord functionality

--- a/src/components/Key.svelte
+++ b/src/components/Key.svelte
@@ -9,12 +9,15 @@
 
     let context, o, g;
 
+    context = new AudioContext()
+
     const generateSound = () =>{
-        context = new AudioContext();
+        //context = new AudioContext();
         o = context.createOscillator();
         g = context.createGain();
         o.type = type;
         o.frequency.value = frequency;
+        
         o.connect(g);
         g.connect(context.destination);
     }
@@ -22,10 +25,13 @@
     generateSound()
 
     const playNote = () => {
+        console.log('hello')
         o.start(0);
+        o.stop(context.currentTime + 1)
         g.gain.exponentialRampToValueAtTime(
             0.0001, context.currentTime + decay
         )
+        
         generateSound();
     }
 


### PR DESCRIPTION
Fixed the bug by making it so that the generateSound function in the Key component doesn't make a new AudioContext object every time the function runs, and creating an instance of the object outside the function. Fixed another bug which causes a note to go on quietly forever. Caused another bug however, if a note is activated in rapid succession, a sharp sound occurs.